### PR TITLE
Improvements to error handling

### DIFF
--- a/src/Balanced/Bootstrap.php
+++ b/src/Balanced/Bootstrap.php
@@ -57,8 +57,6 @@ class Bootstrap
         if (self::$initialized)
             return;
 
-        \Balanced\Errors\Error::init();
-
         \Balanced\Resource::init();
 
         \Balanced\APIKey::init();

--- a/src/Balanced/Errors.php
+++ b/src/Balanced/Errors.php
@@ -58,7 +58,7 @@ class InvalidBankAccountNumber extends Error
 
 class Declined extends Error
 {
-    public static $codes = array('funding-destination-declined', 'authorization-failed');
+    public static $codes = array('funding-destination-declined', 'authorization-failed', 'card-declined');
 }
 
 class CannotAssociateMerchantWithAccount extends Error

--- a/src/Balanced/Errors.php
+++ b/src/Balanced/Errors.php
@@ -8,15 +8,31 @@ class Error extends HTTPError
 {
     public static $codes = array();
     
-    public static function init()
+    protected static function init()
     {
+        $errorClass = get_class();
+        
         foreach (get_declared_classes() as $class) {
-            $parent_class = get_parent_class($class);
-            if ($parent_class != 'Balanced\Errors\Error')
-                continue;
-            foreach ($class::$codes as $type)
-                self::$codes[$type] = $class;
+            if (get_parent_class($class) == $errorClass) {
+                foreach ($class::$codes as $type)
+                    self::$codes[$type] = $class;
+            }
         }
+    }
+    
+    public static function createFromResponse($response)
+    {
+        if (empty(self::$codes))
+            self::init();
+        
+        $code = $response->body->category_code;
+        
+        if (isset(self::$codes[$code]))
+            $cn = self::$codes[$code];
+        else
+            $cn = get_class();
+        
+        return new $cn($response);
     }
 }
 

--- a/src/Balanced/Resource.php
+++ b/src/Balanced/Resource.php
@@ -20,9 +20,8 @@ class Resource extends \RESTful\Resource
 
     public static function convertError($response)
     {
-        if (property_exists($response->body, 'category_code') &&
-            array_key_exists($response->body->category_code, Error::$codes))
-            $error = new Error::$codes[$response->body->category_code]($response);
+        if (property_exists($response->body, 'category_code'))
+            $error = Error::createFromResponse($response);
         else
             $error = new HTTPError($response);
         return $error;

--- a/tests/Balanced/SuiteTest.php
+++ b/tests/Balanced/SuiteTest.php
@@ -237,7 +237,7 @@ class SuiteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RESTful\Exceptions\HTTPError
+     * @expectedException \Balanced\Errors\Error
      */
     function testAnotherMarketplace()
     {
@@ -246,7 +246,7 @@ class SuiteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RESTful\Exceptions\HTTPError
+     * @expectedException \Balanced\Errors\Error
      */
     function testDuplicateEmailAddress()
     {
@@ -307,7 +307,7 @@ class SuiteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RESTful\Exceptions\HTTPError
+     * @expectedException \Balanced\Errors\Error
      */
     function testDebitZero()
     {
@@ -439,7 +439,7 @@ class SuiteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RESTful\Exceptions\HTTPError
+     * @expectedException \Balanced\Errors\Error
      */
     function testCreditRequiresNonZeroAmount()
     {
@@ -454,7 +454,7 @@ class SuiteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RESTful\Exceptions\HTTPError
+     * @expectedException \Balanced\Errors\Error
      */
     function testCreditMoreThanEscrowBalanceFails()
     {
@@ -611,7 +611,7 @@ class SuiteTest extends \PHPUnit_Framework_TestCase
             self::$marketplace->createMerchant(
                 sprintf('m+%d@poundpay.com', self::$email_counter++),
                 $identity);
-        } catch (\RESTful\Exceptions\HTTPError $e) {
+        } catch (\Balanced\Errors\Error $e) {
             $this->assertEquals($e->response->code, 300);
             $expected = sprintf('https://www.balancedpayments.com/marketplaces/%s/kyc', self::$marketplace->id);
             $this->assertEquals($e->redirect_uri, $expected);
@@ -763,7 +763,7 @@ class SuiteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RESTful\Exceptions\HTTPError
+     * @expectedException \Balanced\Errors\Error
      */
     function testGetDeletedBankAccount()
     {
@@ -944,7 +944,7 @@ class SuiteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RESTful\Exceptions\HTTPError
+     * @expectedException \Balanced\Errors\Error
      */
     function testGetDeletedCard()
     {


### PR DESCRIPTION
- Move factory for error classes into Error::createFromResponse (so Resource::convertError doesn't have to know about the internal structure of Error)
- Initialize Error::$codes only if necessary (the first time createFromResponse is called); don't initialize it just because the API is bootstrapped
- Improve Error::init: less code to do the same thing and remove hard-coded class name
- Error::createFromResponse returns an Error if it can't find a match (an improvement over returning an HTTPError)
