### PR TITLE
Test availability of source_uri

### DIFF
--- a/tests/Balanced/SuiteTest.php
+++ b/tests/Balanced/SuiteTest.php
@@ -974,5 +974,6 @@ class SuiteTest extends \PHPUnit_Framework_TestCase
         $card = $this->_createCard();
         $customer->addCard($card->uri);
         $this->assertNotNull($customer->source->uri);
+        $this->assertInstanceOf('Balanced\Card', $customer->source);
     }
 }


### PR DESCRIPTION
Requires bninja/restful 0.1.8

Test now ensures source URI is accessible from Customer. Resolves https://github.com/balanced/balanced-php/issues/63
