### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 .buildpath
 composer.phar
 vendor
-*~
-*#
 # phar
 *.phar
 .DS_Store


### PR DESCRIPTION
Remove gitignore lines that breaks the package dumping do to Composer\Package\Archiver\GitExcludeFilter.

These lines would cause the generated archive package to have no files. When using satis you will then not have any files in the installed package.
