### PR TITLE
Update RESTful source download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ $ unzip httpful.zip; mv nategood-httpful* httpful; rm httpful.zip
 Download [RESTful](https://github.com/matthewfl/restful) source:
 
 ```bash
-$ curl -s -L -o restful.zip https://github.com/matthewfl/restful/zipball/master;
-$ unzip restful.zip; mv matthewfl-restful* restful; rm restful.zip
+$ curl -s -L -o restful.zip https://github.com/matthewfl/restful/archive/v1.0.3.zip;
+$ unzip restful.zip; mv restful-1.0.3* restful; rm restful.zip
 ```
 
 Download the Balanced source:


### PR DESCRIPTION
This change to the "source download" section of the README.md allows the RESTful library to use the same version as specified in the balanced-php composer.json 1.0.3 - this is required to use the new JSONapi data protocol set up by BalancedPayments v1.1 API.

Using instructions as they were before this pull request results is every API call erroring with this type of response:

```
Undefined property: stdClass::$total
```

 in restful/src/RESTful/Page.php where the old-style $data->items is being spawned into Objects.
