### PR TITLE
typo in reversal create scenario

### DIFF
--- a/scenarios/reversal_create/definition.php
+++ b/scenarios/reversal_create/definition.php
@@ -1,1 +1,1 @@
-Balanced\Credit->reverses->create()
+Balanced\Credit->reversals->create()


### PR DESCRIPTION
https://docs.balancedpayments.com/1.1/api/reversals/#create-a-reversal had reverses instead of reversals.
